### PR TITLE
Switch from obsolete express.io to express.oi in order to support newer Node v6.x+

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "esprima": "^3.0.0",
     "express": "^4.14.0",
     "express-session": "^1.12.1",
-    "express.io": "^1.1.13",
+    "express.oi": "git+https://github.com/sibartlett/express.oi.git",
     "formidable": "^1.0.17",
     "fs-extra": "^2.0.0",
     "geojson-area": "^0.2.1",

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,5 @@
 // server.js
-var express  = require('express.io');
+var express  = require('express.oi');
 var mongoose = require('mongoose');
 var flash    = require('connect-flash');
 var path     = require('path');


### PR DESCRIPTION
PR regarding this [issue](https://github.com/mapic/mapic/issues/19) .

